### PR TITLE
add deprecated tags for redis tls and consistent

### DIFF
--- a/examples/examples/redis_database/outputs.tf
+++ b/examples/examples/redis_database/outputs.tf
@@ -84,3 +84,11 @@ output "db_daily_bandwidth_limit" {
 output "db_max_commands_per_second" {
   value = data.upstash_redis_database_data.exampleDBData.db_max_commands_per_second
 }
+
+output "tls" {
+  value = data.upstash_redis_database_data.exampleDBData.tls
+}
+
+output "consistent" {
+  value = data.upstash_redis_database_data.exampleDBData.consistent
+}

--- a/examples/examples/redis_database/resources.tf
+++ b/examples/examples/redis_database/resources.tf
@@ -1,6 +1,5 @@
 resource "upstash_redis_database" "exampleDB" {
   database_name = var.database_name
   region = var.region
-  tls = var.tls
   multizone = var.multizone
 }

--- a/examples/examples/redis_database/resources.tf
+++ b/examples/examples/redis_database/resources.tf
@@ -2,4 +2,6 @@ resource "upstash_redis_database" "exampleDB" {
   database_name = var.database_name
   region = var.region
   multizone = var.multizone
+  tls = true
+  consistent = false
 }

--- a/examples/examples/redis_database/variables.tf
+++ b/examples/examples/redis_database/variables.tf
@@ -9,5 +9,4 @@ variable "api_key" {
 
 variable "database_name"{}
 variable "region"{}
-variable "tls"{}
 variable "multizone"{}

--- a/integrationtesting/upstash_redis_database_test.go
+++ b/integrationtesting/upstash_redis_database_test.go
@@ -80,7 +80,6 @@ func redisDatabaseOptions(t *testing.T) *terraform.Options {
 			"api_key":       apikey,
 			"database_name": redis_database_name,
 			"region":        redis_database_region,
-			"tls":           redis_database_tls,
 			"multizone":     redis_database_multizone,
 		},
 	})

--- a/upstash/redis/database/crud.go
+++ b/upstash/redis/database/crud.go
@@ -19,6 +19,9 @@ func resourceDatabaseUpdate(ctx context.Context, data *schema.ResourceData, m in
 	}
 
 	if data.HasChange("tls") {
+		if !data.Get("tls").(bool) {
+			return diag.Errorf("Cannot disable tls on the DB. All the newly created DBs will be TLS enabled.")
+		}
 		if err := EnableTLS(c, databaseId); err != nil {
 			return diag.FromErr(err)
 		}
@@ -76,6 +79,9 @@ func resourceDatabaseRead(ctx context.Context, data *schema.ResourceData, m inte
 }
 
 func resourceDatabaseCreate(ctx context.Context, data *schema.ResourceData, m interface{}) diag.Diagnostics {
+	if !data.Get("tls").(bool) {
+		return diag.Errorf("Cannot create new DB with tls disabled.")
+	}
 	c := m.(*client.UpstashClient)
 	database, err := CreateDatabase(c, CreateDatabaseRequest{
 		Region:       data.Get("region").(string),

--- a/upstash/redis/database/data_source.go
+++ b/upstash/redis/database/data_source.go
@@ -37,6 +37,7 @@ func DataSourceDatabase() *schema.Resource {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "When enabled database runs in Consistency Mode",
+				Deprecated:  "Consistent option is deprecated.",
 			},
 			"multizone": &schema.Schema{
 				Type:        schema.TypeBool,
@@ -47,6 +48,7 @@ func DataSourceDatabase() *schema.Resource {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "When enabled data is encrypted in transit",
+				Deprecated:  "TLS option is deprecated.",
 			},
 			"port": &schema.Schema{
 				Type:        schema.TypeInt,

--- a/upstash/redis/database/resource.go
+++ b/upstash/redis/database/resource.go
@@ -50,6 +50,7 @@ func ResourceDatabase() *schema.Resource {
 				Default:     false,
 				ForceNew:    true,
 				Description: "When enabled, all writes are synchronously persisted to the disk.",
+				Deprecated:  "Consistent option is deprecated.",
 			},
 			"multizone": &schema.Schema{
 				Type:        schema.TypeBool,
@@ -62,6 +63,7 @@ func ResourceDatabase() *schema.Resource {
 				Optional:    true,
 				Default:     false,
 				Description: "When enabled, data is encrypted in transit. (If changed to false from true, results in deletion and recreation of the resource)",
+				Deprecated:  "TLS option is deprecated.",
 			},
 			"port": &schema.Schema{
 				Type:        schema.TypeInt,

--- a/upstash/redis/database/resource.go
+++ b/upstash/redis/database/resource.go
@@ -45,10 +45,10 @@ func ResourceDatabase() *schema.Resource {
 				Description: "Password of the database",
 			},
 			"consistent": &schema.Schema{
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     false,
-				ForceNew:    true,
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				// ForceNew:    true,
 				Description: "When enabled, all writes are synchronously persisted to the disk.",
 				Deprecated:  "Consistent option is deprecated.",
 			},
@@ -61,9 +61,9 @@ func ResourceDatabase() *schema.Resource {
 			"tls": &schema.Schema{
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     false,
+				Computed:    true,
 				Description: "When enabled, data is encrypted in transit. (If changed to false from true, results in deletion and recreation of the resource)",
-				Deprecated:  "TLS option is deprecated.",
+				Deprecated:  "TLS option is deprecated. TLS will always be enabled. If you have a DB without tls enabled, run the same configuration with tls=true to enable it.",
 			},
 			"port": &schema.Schema{
 				Type:        schema.TypeInt,
@@ -140,9 +140,6 @@ func ResourceDatabase() *schema.Resource {
 
 		CustomizeDiff: customdiff.All(
 			customdiff.ForceNewIfChange("multizone", func(ctx context.Context, old, new, meta interface{}) bool {
-				return old.(bool) && !new.(bool)
-			}),
-			customdiff.ForceNewIfChange("tls", func(ctx context.Context, old, new, meta interface{}) bool {
 				return old.(bool) && !new.(bool)
 			}),
 		),

--- a/upstash/redis/database/resource.go
+++ b/upstash/redis/database/resource.go
@@ -45,10 +45,9 @@ func ResourceDatabase() *schema.Resource {
 				Description: "Password of the database",
 			},
 			"consistent": &schema.Schema{
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-				// ForceNew:    true,
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
 				Description: "When enabled, all writes are synchronously persisted to the disk.",
 				Deprecated:  "Consistent option is deprecated.",
 			},
@@ -140,6 +139,9 @@ func ResourceDatabase() *schema.Resource {
 
 		CustomizeDiff: customdiff.All(
 			customdiff.ForceNewIfChange("multizone", func(ctx context.Context, old, new, meta interface{}) bool {
+				return old.(bool) && !new.(bool)
+			}),
+			customdiff.ForceNewIfChange("consistent", func(ctx context.Context, old, new, meta interface{}) bool {
 				return old.(bool) && !new.(bool)
 			}),
 		),


### PR DESCRIPTION
For this minor version, added the deprecated tags. This will show the users a warning saying that the options are deprecated. 

With the next major version, all the code relevant to those parameters will be removed from the provider.