### PR TITLE
Terraform format example data sources and resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ terraform {
 }
 
 provider "upstash" {
-  email = var.email
+  email    = var.email
   api_key  = var.api_key
 }
 ```
@@ -32,9 +32,9 @@ Here example code snippet that creates database:
 ```hcl
 resource "upstash_redis_database" "redis" {
   database_name = "db-name"
-  region = "eu-west-1"
-  tls = "true"
-  multi_zone = "false"
+  region        = "eu-west-1"
+  tls           = "true"
+  multi_zone    = "false"
 }
 ```
 ## Import Resources From Outside of Terraform
@@ -73,7 +73,6 @@ If you want to locally build/test the provider then follow these steps:
 * Now your `terraform` commands will use local Upstash provider. 
 ```hcl
 provider_installation {
-
   dev_overrides {
     "upstash" = "[PATH THAT CONTAINS CUSTOM PROVIDER]"
   }

--- a/examples/data-sources/upstash_kafka_connector_data/data-source.tf
+++ b/examples/data-sources/upstash_kafka_connector_data/data-source.tf
@@ -1,3 +1,3 @@
 data "upstash_kafka_connector_data" "kafkaConnectorData" {
-    topic_id = resource.upstash_kafka_connector.exampleKafkaConnector.connector_id
+  topic_id = resource.upstash_kafka_connector.exampleKafkaConnector.connector_id
 }

--- a/examples/data-sources/upstash_kafka_credential_data/data-source.tf
+++ b/examples/data-sources/upstash_kafka_credential_data/data-source.tf
@@ -1,3 +1,3 @@
 data "upstash_kafka_credential_data" "kafkaCredentialData" {
-    credential_id = upstash_kafka_credential.exampleKafkaCredential.credential_id
+  credential_id = upstash_kafka_credential.exampleKafkaCredential.credential_id
 }

--- a/examples/data-sources/upstash_kafka_topic_data/data-source.tf
+++ b/examples/data-sources/upstash_kafka_topic_data/data-source.tf
@@ -1,3 +1,3 @@
 data "upstash_kafka_topic_data" "kafkaTopicData" {
-    topic_id = resource.upstash_kafka_topic.exampleKafkaTopic.topic_id
+  topic_id = resource.upstash_kafka_topic.exampleKafkaTopic.topic_id
 }

--- a/examples/data-sources/upstash_qstash_endpoint_data/data-source.tf
+++ b/examples/data-sources/upstash_qstash_endpoint_data/data-source.tf
@@ -1,3 +1,3 @@
 data "upstash_qstash_endpoint_data" "exampleQstashEndpointData" {
-    endpoint_id = resource.upstash_qstash_endpoint.exampleQstashEndpoint.endpoint_id
+  endpoint_id = resource.upstash_qstash_endpoint.exampleQstashEndpoint.endpoint_id
 }

--- a/examples/data-sources/upstash_qstash_schedule_data/data-source.tf
+++ b/examples/data-sources/upstash_qstash_schedule_data/data-source.tf
@@ -1,3 +1,3 @@
 data "upstash_qstash_schedule_data" "exampleQstashScheduleData" {
-    schedule_id = resource.upstash_qstash_schedule.exampleQstashSchedule.schedule_id
+  schedule_id = resource.upstash_qstash_schedule.exampleQstashSchedule.schedule_id
 }

--- a/examples/data-sources/upstash_qstash_topic_date/data-source.tf
+++ b/examples/data-sources/upstash_qstash_topic_date/data-source.tf
@@ -1,3 +1,3 @@
 data "upstash_qstash_topic_data" "exampleQstashTopicData" {
-    topic_id = resource.upstash_qstash_topic.exampleQstashTopic.topic_id
+  topic_id = resource.upstash_qstash_topic.exampleQstashTopic.topic_id
 }

--- a/examples/data-sources/upstash_redis_database_data/data-source.tf
+++ b/examples/data-sources/upstash_redis_database_data/data-source.tf
@@ -1,3 +1,3 @@
 data "upstash_redis_database_data" "exampleDBData" {
-    database_id = resource.upstash_redis_database.exampleDB.database_id
+  database_id = resource.upstash_redis_database.exampleDB.database_id
 }

--- a/examples/data-sources/upstash_team_data/data-source.tf
+++ b/examples/data-sources/upstash_team_data/data-source.tf
@@ -1,3 +1,3 @@
 data "upstash_team_data" "teamData" {
-    team_id = resource.upstash_team.exampleTeam.team_id
+  team_id = resource.upstash_team.exampleTeam.team_id
 }

--- a/examples/examples/dbAndCluster/data.tf
+++ b/examples/examples/dbAndCluster/data.tf
@@ -1,5 +1,5 @@
 data "upstash_redis_database_data" "databaseData" {
-    database_id = resource.upstash_redis_database.redis.database_id
+  database_id = resource.upstash_redis_database.redis.database_id
 }
 
 data "upstash_kafka_cluster_data" "clusterData" {

--- a/examples/examples/dbAndCluster/outputs.tf
+++ b/examples/examples/dbAndCluster/outputs.tf
@@ -5,11 +5,11 @@ output "cluster_id" {
 }
 
 output "cluster_name" {
-  value = data.upstash_kafka_cluster_data.clusterData.cluster_name 
+  value = data.upstash_kafka_cluster_data.clusterData.cluster_name
 }
 
 output "cluster_region" {
-  value = data.upstash_kafka_cluster_data.clusterData.region 
+  value = data.upstash_kafka_cluster_data.clusterData.region
 }
 
 output "cluster_type" {
@@ -38,7 +38,7 @@ output "cluster_username" {
 
 
 output "cluster_password" {
-  value = data.upstash_kafka_cluster_data.clusterData.password
+  value     = data.upstash_kafka_cluster_data.clusterData.password
   sensitive = true
 }
 

--- a/examples/examples/dbAndCluster/providers.tf
+++ b/examples/examples/dbAndCluster/providers.tf
@@ -1,4 +1,4 @@
 provider "upstash" {
   api_key = "FILL_HERE"
-  email = "FILL_HERE"
+  email   = "FILL_HERE"
 }

--- a/examples/examples/dbAndCluster/resources.tf
+++ b/examples/examples/dbAndCluster/resources.tf
@@ -1,13 +1,13 @@
 resource "upstash_redis_database" "redis" {
   database_name = "Terraform_Upstash_Database"
-  region = "eu-west-1"
-  tls = true
-  multizone = false
-  consistent = true
+  region        = "eu-west-1"
+  tls           = true
+  multizone     = false
+  consistent    = true
 }
 
 resource "upstash_kafka_cluster" "exampleCluster" {
   cluster_name = "Terraform_Upstash_Cluster"
-  region = "eu-west-1"
-  multizone = false
+  region       = "eu-west-1"
+  multizone    = false
 }

--- a/examples/examples/kafka_cluster/outputs.tf
+++ b/examples/examples/kafka_cluster/outputs.tf
@@ -3,11 +3,11 @@ output "cluster_id" {
 }
 
 output "cluster_name" {
-  value = data.upstash_kafka_cluster_data.clusterData.cluster_name 
+  value = data.upstash_kafka_cluster_data.clusterData.cluster_name
 }
 
 output "region" {
-  value = data.upstash_kafka_cluster_data.clusterData.region 
+  value = data.upstash_kafka_cluster_data.clusterData.region
 }
 
 output "type" {
@@ -35,7 +35,7 @@ output "username" {
 }
 
 output "password" {
-  value = data.upstash_kafka_cluster_data.clusterData.password
+  value     = data.upstash_kafka_cluster_data.clusterData.password
   sensitive = true
 }
 

--- a/examples/examples/kafka_cluster/providers.tf
+++ b/examples/examples/kafka_cluster/providers.tf
@@ -1,4 +1,4 @@
 provider "upstash" {
-  email = var.email
+  email   = var.email
   api_key = var.api_key
 }

--- a/examples/examples/kafka_cluster/resources.tf
+++ b/examples/examples/kafka_cluster/resources.tf
@@ -1,8 +1,8 @@
 
 resource "upstash_kafka_cluster" "exampleCluster" {
   cluster_name = var.cluster_name
-  region = var.region
-  multizone = var.multizone
+  region       = var.region
+  multizone    = var.multizone
 }
 
 # resource "upstash_kafka_cluster" "importCluster" {}

--- a/examples/examples/kafka_cluster/variables.tf
+++ b/examples/examples/kafka_cluster/variables.tf
@@ -7,12 +7,12 @@ variable "api_key" {
   default     = ""
 }
 
-variable "cluster_name"{
+variable "cluster_name" {
   default = "terraform_cluster"
 }
-variable "region"{
+variable "region" {
   default = "eu-west-1"
 }
-variable "multizone"{
+variable "multizone" {
   default = false
 }

--- a/examples/examples/kafka_connector/data.tf
+++ b/examples/examples/kafka_connector/data.tf
@@ -1,4 +1,4 @@
 data "upstash_kafka_connector_data" "exampleKafkaConnectorData" {
-    connector_id = upstash_kafka_connector.exampleKafkaConnector.connector_id
+  connector_id = upstash_kafka_connector.exampleKafkaConnector.connector_id
 }
 

--- a/examples/examples/kafka_connector/outputs.tf
+++ b/examples/examples/kafka_connector/outputs.tf
@@ -1,7 +1,7 @@
 output "state" {
-    value=data.upstash_kafka_connector_data.exampleKafkaConnectorData.state
+  value = data.upstash_kafka_connector_data.exampleKafkaConnectorData.state
 }
 
 output "connector_state" {
-    value=data.upstash_kafka_connector_data.exampleKafkaConnectorData.connector_state
+  value = data.upstash_kafka_connector_data.exampleKafkaConnectorData.connector_state
 }

--- a/examples/examples/kafka_connector/provider.tf
+++ b/examples/examples/kafka_connector/provider.tf
@@ -1,4 +1,4 @@
 provider "upstash" {
-  email = var.email
+  email   = var.email
   api_key = var.api_key
 }

--- a/examples/examples/kafka_connector/resources.tf
+++ b/examples/examples/kafka_connector/resources.tf
@@ -1,35 +1,35 @@
 resource "upstash_kafka_cluster" "exampleKafkaCluster" {
-    cluster_name = var.cluster_name
-    region = var.region
-    multizone = var.multizone
+  cluster_name = var.cluster_name
+  region       = var.region
+  multizone    = var.multizone
 }
 
 resource "upstash_kafka_topic" "exampleKafkaTopic" {
-    topic_name = "TerraformTopic"
-    partitions = 1
-    retention_time = 625135
-    retention_size = 725124
-    max_message_size = 829213
-    cleanup_policy = "delete"
-    
-    # Here, you can use the newly created kafka_cluster resource (above) named exampleKafkaCluster.
-    # And use its ID so that the topic binds to it.
+  topic_name       = "TerraformTopic"
+  partitions       = 1
+  retention_time   = 625135
+  retention_size   = 725124
+  max_message_size = 829213
+  cleanup_policy   = "delete"
 
-    # Alternatively, provide the ID of an already created cluster.
-    cluster_id = resource.upstash_kafka_cluster.exampleKafkaCluster.cluster_id
+  # Here, you can use the newly created kafka_cluster resource (above) named exampleKafkaCluster.
+  # And use its ID so that the topic binds to it.
+
+  # Alternatively, provide the ID of an already created cluster.
+  cluster_id = resource.upstash_kafka_cluster.exampleKafkaCluster.cluster_id
 }
 
 resource "upstash_kafka_connector" "exampleKafkaConnector" {
-    name = var.connector_name
-    cluster_id = upstash_kafka_cluster.exampleKafkaCluster.cluster_id
-    properties = {
-        "collection": "user123",
-        "connection.uri": "mongodb+srv://test:test@cluster0.fohyg7p.mongodb.net/?retryWrites=true&w=majority",
-        "connector.class": "com.mongodb.kafka.connect.MongoSourceConnector",
-        "database": "myshinynewdb2"
-        "topics": "${upstash_kafka_topic.exampleKafkaTopic.topic_name}"
-    }
-    running_state = "running"
+  name       = var.connector_name
+  cluster_id = upstash_kafka_cluster.exampleKafkaCluster.cluster_id
+  properties = {
+    "collection" : "user123",
+    "connection.uri" : "mongodb+srv://test:test@cluster0.fohyg7p.mongodb.net/?retryWrites=true&w=majority",
+    "connector.class" : "com.mongodb.kafka.connect.MongoSourceConnector",
+    "database" : "myshinynewdb2"
+    "topics" : "${upstash_kafka_topic.exampleKafkaTopic.topic_name}"
+  }
+  running_state = "running"
 }
 
 

--- a/examples/examples/kafka_connector/variables.tf
+++ b/examples/examples/kafka_connector/variables.tf
@@ -1,22 +1,22 @@
 variable "email" {
   description = "Upstash user email"
-  default = ""
+  default     = ""
 }
 variable "api_key" {
   description = "Api key for the given user"
-  default = ""
+  default     = ""
 }
 
-variable "cluster_name"{
+variable "cluster_name" {
   default = "clusterForConnector"
 }
-variable "region"{
-  default = "eu-west-1" 
+variable "region" {
+  default = "eu-west-1"
 }
-variable "multizone"{
+variable "multizone" {
   default = false
 }
 
-variable "connector_name"{
-    default = "test_connector2"
+variable "connector_name" {
+  default = "test_connector2"
 }

--- a/examples/examples/kafka_connector/versions.tf
+++ b/examples/examples/kafka_connector/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     upstash = {
-      source = "upstash/upstash"
+      source  = "upstash/upstash"
       version = "X.X.X"
     }
   }

--- a/examples/examples/kafka_credential/data.tf
+++ b/examples/examples/kafka_credential/data.tf
@@ -1,11 +1,11 @@
 data "upstash_kafka_topic_data" "kafkaTopicData" {
-    topic_id = resource.upstash_kafka_topic.exampleKafkaTopic.topic_id
+  topic_id = resource.upstash_kafka_topic.exampleKafkaTopic.topic_id
 }
 
 data "upstash_kafka_cluster_data" "kafkaClusterData" {
-    cluster_id = resource.upstash_kafka_cluster.exampleKafkaCluster.cluster_id
+  cluster_id = resource.upstash_kafka_cluster.exampleKafkaCluster.cluster_id
 }
 
 data "upstash_kafka_credential_data" "kafkaCredentialData" {
-    credential_id = upstash_kafka_credential.exampleKafkaCredential.credential_id
+  credential_id = upstash_kafka_credential.exampleKafkaCredential.credential_id
 }

--- a/examples/examples/kafka_credential/outputs.tf
+++ b/examples/examples/kafka_credential/outputs.tf
@@ -1,65 +1,65 @@
 
 // Topic outputs
 output "topic_id" {
-    value = data.upstash_kafka_topic_data.kafkaTopicData.topic_id
+  value = data.upstash_kafka_topic_data.kafkaTopicData.topic_id
 }
 output "topic_name" {
-    value = data.upstash_kafka_topic_data.kafkaTopicData.topic_name
+  value = data.upstash_kafka_topic_data.kafkaTopicData.topic_name
 }
 output "partitions" {
-    value = data.upstash_kafka_topic_data.kafkaTopicData.partitions
+  value = data.upstash_kafka_topic_data.kafkaTopicData.partitions
 }
 
 output "retention_time" {
-    value = data.upstash_kafka_topic_data.kafkaTopicData.retention_time
+  value = data.upstash_kafka_topic_data.kafkaTopicData.retention_time
 }
 output "retention_size" {
-    value = data.upstash_kafka_topic_data.kafkaTopicData.retention_size
+  value = data.upstash_kafka_topic_data.kafkaTopicData.retention_size
 }
 
 output "max_message_size" {
-    value = data.upstash_kafka_topic_data.kafkaTopicData.max_message_size
+  value = data.upstash_kafka_topic_data.kafkaTopicData.max_message_size
 }
 
 output "cleanup_policy" {
-    value = data.upstash_kafka_topic_data.kafkaTopicData.cleanup_policy
+  value = data.upstash_kafka_topic_data.kafkaTopicData.cleanup_policy
 }
 
 output "creation_time_topic" {
-    value = data.upstash_kafka_topic_data.kafkaTopicData.creation_time
+  value = data.upstash_kafka_topic_data.kafkaTopicData.creation_time
 }
 
 // cluster outputs
 output "cluster_id" {
-    value = data.upstash_kafka_cluster_data.kafkaClusterData.cluster_id
+  value = data.upstash_kafka_cluster_data.kafkaClusterData.cluster_id
 }
 output "cluster_name" {
-    value = data.upstash_kafka_cluster_data.kafkaClusterData.cluster_name
+  value = data.upstash_kafka_cluster_data.kafkaClusterData.cluster_name
 }
 output "region" {
-    value = data.upstash_kafka_cluster_data.kafkaClusterData.region
+  value = data.upstash_kafka_cluster_data.kafkaClusterData.region
 }
 output "multizone" {
-    value = data.upstash_kafka_cluster_data.kafkaClusterData.multizone
+  value = data.upstash_kafka_cluster_data.kafkaClusterData.multizone
 }
 output "creation_time_cluster" {
-    value = data.upstash_kafka_cluster_data.kafkaClusterData.creation_time
+  value = data.upstash_kafka_cluster_data.kafkaClusterData.creation_time
 }
 
 
 
 output "credential_id" {
-    value = data.upstash_kafka_credential_data.kafkaCredentialData.credential_id
+  value = data.upstash_kafka_credential_data.kafkaCredentialData.credential_id
 }
 
 output "credential_name" {
-    value = data.upstash_kafka_credential_data.kafkaCredentialData.credential_name
+  value = data.upstash_kafka_credential_data.kafkaCredentialData.credential_name
 }
 
 output "credential_permissions" {
-    value = data.upstash_kafka_credential_data.kafkaCredentialData.permissions
+  value = data.upstash_kafka_credential_data.kafkaCredentialData.permissions
 }
 
 output "credential_topic" {
-    value = data.upstash_kafka_credential_data.kafkaCredentialData.topic
+  value = data.upstash_kafka_credential_data.kafkaCredentialData.topic
 }

--- a/examples/examples/kafka_credential/providers.tf
+++ b/examples/examples/kafka_credential/providers.tf
@@ -1,4 +1,4 @@
 provider "upstash" {
-  email = var.email
+  email   = var.email
   api_key = var.api_key
 }

--- a/examples/examples/kafka_credential/resources.tf
+++ b/examples/examples/kafka_credential/resources.tf
@@ -1,32 +1,32 @@
 resource "upstash_kafka_cluster" "exampleKafkaCluster" {
-    cluster_name = var.cluster_name
-    region = var.region
-    multizone = var.multizone
+  cluster_name = var.cluster_name
+  region       = var.region
+  multizone    = var.multizone
 }
 
 
 resource "upstash_kafka_topic" "exampleKafkaTopic" {
-    topic_name = var.topic_name
-    partitions = var.partitions
-    retention_time = var.retention_time
-    retention_size = var.retention_size
-    max_message_size = var.max_message_size
-    cleanup_policy = var.cleanup_policy
-    cluster_id = resource.upstash_kafka_cluster.exampleKafkaCluster.cluster_id
+  topic_name       = var.topic_name
+  partitions       = var.partitions
+  retention_time   = var.retention_time
+  retention_size   = var.retention_size
+  max_message_size = var.max_message_size
+  cleanup_policy   = var.cleanup_policy
+  cluster_id       = resource.upstash_kafka_cluster.exampleKafkaCluster.cluster_id
 }
 
 resource "upstash_kafka_credential" "exampleKafkaCredential" {
-    cluster_id = upstash_kafka_cluster.exampleKafkaCluster.cluster_id
-    credential_name=var.credential_name
-    topic = upstash_kafka_topic.exampleKafkaTopic.topic_name
-    permissions = var.credential_permissions
+  cluster_id      = upstash_kafka_cluster.exampleKafkaCluster.cluster_id
+  credential_name = var.credential_name
+  topic           = upstash_kafka_topic.exampleKafkaTopic.topic_name
+  permissions     = var.credential_permissions
 }
 
 resource "upstash_kafka_credential" "exampleKafkaCredentialAllTopics" {
-  cluster_id = upstash_kafka_cluster.exampleKafkaCluster.cluster_id
-  credential_name="credentialFromTerraform"
-  topic = "*"
-  permissions = "ALL"
+  cluster_id      = upstash_kafka_cluster.exampleKafkaCluster.cluster_id
+  credential_name = "credentialFromTerraform"
+  topic           = "*"
+  permissions     = "ALL"
 }
 
 # resource "upstash_kafka_credential" "importKafkaCredential" {}

--- a/examples/examples/kafka_credential/variables.tf
+++ b/examples/examples/kafka_credential/variables.tf
@@ -1,40 +1,40 @@
 variable "email" {
   description = "Upstash user email"
-  default = ""
+  default     = ""
 }
 variable "api_key" {
   description = "Api key for the given user"
-  default = ""
+  default     = ""
 }
 
-variable "cluster_name"{
+variable "cluster_name" {
   default = "clusterForCredential"
 }
-variable "region"{
-  default = "eu-west-1" 
+variable "region" {
+  default = "eu-west-1"
 }
-variable "multizone"{
+variable "multizone" {
   default = false
 }
 
-variable "topic_name"{
+variable "topic_name" {
   default = "topicForCredential"
 }
-variable "partitions"{
+variable "partitions" {
   default = 2
 }
-variable "retention_time"{
+variable "retention_time" {
   default = 100000
 }
-variable "retention_size"{
+variable "retention_size" {
   default = 100000
 }
-variable "max_message_size"{
+variable "max_message_size" {
   default = 100000
 }
-variable "cleanup_policy"{
+variable "cleanup_policy" {
   default = "delete"
 }
 
-variable "credential_name"{}
-variable "credential_permissions"{}
+variable "credential_name" {}
+variable "credential_permissions" {}

--- a/examples/examples/kafka_topic/data.tf
+++ b/examples/examples/kafka_topic/data.tf
@@ -1,7 +1,7 @@
 data "upstash_kafka_topic_data" "kafkaTopicData" {
-    topic_id = resource.upstash_kafka_topic.exampleKafkaTopic.topic_id
+  topic_id = resource.upstash_kafka_topic.exampleKafkaTopic.topic_id
 }
 
 data "upstash_kafka_cluster_data" "kafkaClusterData" {
-    cluster_id = resource.upstash_kafka_cluster.exampleKafkaCluster.cluster_id
+  cluster_id = resource.upstash_kafka_cluster.exampleKafkaCluster.cluster_id
 }

--- a/examples/examples/kafka_topic/outputs.tf
+++ b/examples/examples/kafka_topic/outputs.tf
@@ -1,47 +1,47 @@
 
 // Topic outputs
 output "topic_id" {
-    value = data.upstash_kafka_topic_data.kafkaTopicData.topic_id
+  value = data.upstash_kafka_topic_data.kafkaTopicData.topic_id
 }
 output "topic_name" {
-    value = data.upstash_kafka_topic_data.kafkaTopicData.topic_name
+  value = data.upstash_kafka_topic_data.kafkaTopicData.topic_name
 }
 output "partitions" {
-    value = data.upstash_kafka_topic_data.kafkaTopicData.partitions
+  value = data.upstash_kafka_topic_data.kafkaTopicData.partitions
 }
 
 output "retention_time" {
-    value = data.upstash_kafka_topic_data.kafkaTopicData.retention_time
+  value = data.upstash_kafka_topic_data.kafkaTopicData.retention_time
 }
 output "retention_size" {
-    value = data.upstash_kafka_topic_data.kafkaTopicData.retention_size
+  value = data.upstash_kafka_topic_data.kafkaTopicData.retention_size
 }
 
 output "max_message_size" {
-    value = data.upstash_kafka_topic_data.kafkaTopicData.max_message_size
+  value = data.upstash_kafka_topic_data.kafkaTopicData.max_message_size
 }
 
 output "cleanup_policy" {
-    value = data.upstash_kafka_topic_data.kafkaTopicData.cleanup_policy
+  value = data.upstash_kafka_topic_data.kafkaTopicData.cleanup_policy
 }
 
 output "creation_time_topic" {
-    value = data.upstash_kafka_topic_data.kafkaTopicData.creation_time
+  value = data.upstash_kafka_topic_data.kafkaTopicData.creation_time
 }
 
 // cluster outputs
 output "cluster_id" {
-    value = data.upstash_kafka_cluster_data.kafkaClusterData.cluster_id
+  value = data.upstash_kafka_cluster_data.kafkaClusterData.cluster_id
 }
 output "cluster_name" {
-    value = data.upstash_kafka_cluster_data.kafkaClusterData.cluster_name
+  value = data.upstash_kafka_cluster_data.kafkaClusterData.cluster_name
 }
 output "region" {
-    value = data.upstash_kafka_cluster_data.kafkaClusterData.region
+  value = data.upstash_kafka_cluster_data.kafkaClusterData.region
 }
 output "multizone" {
-    value = data.upstash_kafka_cluster_data.kafkaClusterData.multizone
+  value = data.upstash_kafka_cluster_data.kafkaClusterData.multizone
 }
 output "creation_time_cluster" {
-    value = data.upstash_kafka_cluster_data.kafkaClusterData.creation_time
+  value = data.upstash_kafka_cluster_data.kafkaClusterData.creation_time
 }

--- a/examples/examples/kafka_topic/providers.tf
+++ b/examples/examples/kafka_topic/providers.tf
@@ -1,4 +1,4 @@
 provider "upstash" {
-  email = var.email
+  email   = var.email
   api_key = var.api_key
 }

--- a/examples/examples/kafka_topic/resources.tf
+++ b/examples/examples/kafka_topic/resources.tf
@@ -1,22 +1,22 @@
 resource "upstash_kafka_cluster" "exampleKafkaCluster" {
-    cluster_name = var.cluster_name
-    region = var.region
-    multizone = var.multizone
+  cluster_name = var.cluster_name
+  region       = var.region
+  multizone    = var.multizone
 }
 
 
 resource "upstash_kafka_topic" "exampleKafkaTopic" {
-    topic_name = var.topic_name
-    partitions = var.partitions
-    retention_time = var.retention_time
-    retention_size = var.retention_size
-    max_message_size = var.max_message_size
-    cleanup_policy = var.cleanup_policy
-    cluster_id = resource.upstash_kafka_cluster.exampleKafkaCluster.cluster_id
+  topic_name       = var.topic_name
+  partitions       = var.partitions
+  retention_time   = var.retention_time
+  retention_size   = var.retention_size
+  max_message_size = var.max_message_size
+  cleanup_policy   = var.cleanup_policy
+  cluster_id       = resource.upstash_kafka_cluster.exampleKafkaCluster.cluster_id
 
-    # Or, if you defined locals, you can use those as such 
-    # retention_size = local.retention_size_bytes
-    # max_message_size = local.max_message_size_bytes
+  # Or, if you defined locals, you can use those as such 
+  # retention_size = local.retention_size_bytes
+  # max_message_size = local.max_message_size_bytes
 }
 
 

--- a/examples/examples/kafka_topic/variables.tf
+++ b/examples/examples/kafka_topic/variables.tf
@@ -1,23 +1,23 @@
 variable "email" {
   description = "Upstash user email"
-  default = ""
+  default     = ""
 }
 variable "api_key" {
   description = "Api key for the given user"
-  default = ""
+  default     = ""
 }
 
-variable "cluster_name"{}
-variable "region"{}
-variable "multizone"{}
+variable "cluster_name" {}
+variable "region" {}
+variable "multizone" {}
 
 
-variable "topic_name"{}
-variable "partitions"{}
-variable "retention_time"{}
-variable "retention_size"{}
-variable "max_message_size"{}
-variable "cleanup_policy"{}
+variable "topic_name" {}
+variable "partitions" {}
+variable "retention_time" {}
+variable "retention_size" {}
+variable "max_message_size" {}
+variable "cleanup_policy" {}
 
 
 # OR, you can use locals to convert higher numbers to bytes

--- a/examples/examples/qstash_schedule/qstash-general.tf
+++ b/examples/examples/qstash_schedule/qstash-general.tf
@@ -1,46 +1,46 @@
 resource "upstash_qstash_topic" "exampleQstashTopic" {
-    name = "terraform_qstash_topic"
+  name = "terraform_qstash_topic"
 }
 
 resource "upstash_qstash_endpoint" "ep" {
-    url = "https://testing.com"
-    topic_id = resource.upstash_qstash_topic.exampleQstashTopic.topic_id
+  url      = "https://testing.com"
+  topic_id = resource.upstash_qstash_topic.exampleQstashTopic.topic_id
 }
 
 resource "upstash_qstash_endpoint" "ep2" {
-    url = "https://testing2.com"
-    topic_id = resource.upstash_qstash_topic.exampleQstashTopic.topic_id
+  url      = "https://testing2.com"
+  topic_id = resource.upstash_qstash_topic.exampleQstashTopic.topic_id
 }
 
 resource "upstash_qstash_schedule" "sch" {
-    destination = resource.upstash_qstash_topic.exampleQstashTopic.topic_id
-    cron = "* * * * */2"
-    body = "{\"key\": \"value\"}"
-    callback = "https://your-domain.x/qstash-callback"
-    forward_headers = {
-        My-Header : "My-value"
-        My-Header2 : "My-value2"
-    }
+  destination = resource.upstash_qstash_topic.exampleQstashTopic.topic_id
+  cron        = "* * * * */2"
+  body        = "{\"key\": \"value\"}"
+  callback    = "https://your-domain.x/qstash-callback"
+  forward_headers = {
+    My-Header : "My-value"
+    My-Header2 : "My-value2"
+  }
 }
 
 output "topic_id" {
-    value = resource.upstash_qstash_topic.exampleQstashTopic.topic_id
+  value = resource.upstash_qstash_topic.exampleQstashTopic.topic_id
 }
 
 output "endpoint_id" {
-    value = resource.upstash_qstash_endpoint.ep.endpoint_id
+  value = resource.upstash_qstash_endpoint.ep.endpoint_id
 }
 
 output "schedule_id" {
-    value = resource.upstash_qstash_schedule.sch.schedule_id
+  value = resource.upstash_qstash_schedule.sch.schedule_id
 }
 
 output "endpoints_of_topic" {
-    value = resource.upstash_qstash_topic.exampleQstashTopic.endpoints
+  value = resource.upstash_qstash_topic.exampleQstashTopic.endpoints
 }
 
 output "endpoints_of_topic2" {
-    value = resource.upstash_qstash_schedule.sch.body
+  value = resource.upstash_qstash_schedule.sch.body
 }
 
 

--- a/examples/examples/qstash_schedule_v2/main.tf
+++ b/examples/examples/qstash_schedule_v2/main.tf
@@ -1,30 +1,30 @@
 resource "upstash_qstash_topic_v2" "exampleQstashTopicNew" {
-    name = "terraform_qstash_topic"
-    endpoints = ["https://google.com"]
+  name      = "terraform_qstash_topic"
+  endpoints = ["https://google.com"]
 }
 
 resource "upstash_qstash_schedule_v2" "exampleQstashSchedule" {
-    destination = upstash_qstash_topic_v2.exampleQstashTopicNew.name
-    cron = "* * * * */2"
-    delay = 3600
+  destination = upstash_qstash_topic_v2.exampleQstashTopicNew.name
+  cron        = "* * * * */2"
+  delay       = 3600
 }
 
 resource "upstash_qstash_schedule_v2" "exampleQstashSchedule2" {
-    destination = "https://google.com"
-    cron = "* * * * */3"
-    forward_headers = {
-        My-Header : "My-value"
-        My-Header2 : "My-value2"
-    }
-    callback = "https://testing-url.com"
-    body = "{\"key\": \"value\"}"
-    method = "GET"
+  destination = "https://google.com"
+  cron        = "* * * * */3"
+  forward_headers = {
+    My-Header : "My-value"
+    My-Header2 : "My-value2"
+  }
+  callback = "https://testing-url.com"
+  body     = "{\"key\": \"value\"}"
+  method   = "GET"
 }
 
 data "upstash_qstash_schedule_v2_data" "qstashData" {
-    schedule_id = upstash_qstash_schedule_v2.exampleQstashSchedule2.schedule_id
+  schedule_id = upstash_qstash_schedule_v2.exampleQstashSchedule2.schedule_id
 }
 
-output exampleOutput {
-    value = data.upstash_qstash_schedule_v2_data.qstashData
+output "exampleOutput" {
+  value = data.upstash_qstash_schedule_v2_data.qstashData
 }

--- a/examples/examples/redis_database/data.tf
+++ b/examples/examples/redis_database/data.tf
@@ -1,3 +1,3 @@
 data "upstash_redis_database_data" "exampleDBData" {
-    database_id = resource.upstash_redis_database.exampleDB.database_id
+  database_id = resource.upstash_redis_database.exampleDB.database_id
 }

--- a/examples/examples/redis_database/outputs.tf
+++ b/examples/examples/redis_database/outputs.tf
@@ -24,7 +24,7 @@ output "db_name" {
 }
 
 output "password" {
-  value = resource.upstash_redis_database.exampleDB
+  value     = resource.upstash_redis_database.exampleDB
   sensitive = true
 }
 
@@ -33,12 +33,12 @@ output "port" {
 }
 
 output "rest_token" {
-  value = data.upstash_redis_database_data.exampleDBData.rest_token
+  value     = data.upstash_redis_database_data.exampleDBData.rest_token
   sensitive = true
 }
 
 output "read_only_rest_token" {
-  value = data.upstash_redis_database_data.exampleDBData.read_only_rest_token
+  value     = data.upstash_redis_database_data.exampleDBData.read_only_rest_token
   sensitive = true
 }
 

--- a/examples/examples/redis_database/providers.tf
+++ b/examples/examples/redis_database/providers.tf
@@ -1,4 +1,4 @@
 provider "upstash" {
-  email = var.email
+  email   = var.email
   api_key = var.api_key
 }

--- a/examples/examples/redis_database/resources.tf
+++ b/examples/examples/redis_database/resources.tf
@@ -1,13 +1,13 @@
 resource "upstash_redis_database" "exampleDB" {
   database_name = var.database_name
-  region = var.region
-  tls = var.tls
-  auto_scale = var.auto_scale
-  eviction = var.eviction
+  region        = var.region
+  tls           = var.tls
+  auto_scale    = var.auto_scale
+  eviction      = var.eviction
 
   // below ones only work if the region is given as "global"
   primary_region = var.primary_region
-  read_regions = var.read_regions
+  read_regions   = var.read_regions
 }
 
 # resource "upstash_redis_database" "importDB" {}

--- a/examples/examples/redis_database/variables.tf
+++ b/examples/examples/redis_database/variables.tf
@@ -7,39 +7,39 @@ variable "api_key" {
   default     = ""
 }
 
-variable "database_name"{
+variable "database_name" {
   default = "terraform_db"
 }
-variable "region"{
+variable "region" {
   type = string
   # default = "global"
   # or for regional, pick a region. eg default="eu-west-1"
 }
 
-variable "tls"{
+variable "tls" {
   default = "false"
 }
-variable "multizone"{
+variable "multizone" {
   default = "true"
 }
 
-variable "eviction"{
+variable "eviction" {
   default = "true"
 }
 
-variable "auto_scale"{
+variable "auto_scale" {
   default = "true"
 }
 
 # below ones only work when region="global"
 variable "primary_region" {
-  type = string
+  type    = string
   default = ""
   # default = "eu-central-1"
 }
 
-variable "read_regions"{
-  type = set(string)
+variable "read_regions" {
+  type    = set(string)
   default = []
   # default = ["us-east-1", "eu-west-1", "ap-southeast-1"]
 }

--- a/examples/examples/team/data.tf
+++ b/examples/examples/team/data.tf
@@ -1,4 +1,4 @@
 data "upstash_team_data" "teamData" {
-    team_id = resource.upstash_team.exampleTeam.team_id
+  team_id = resource.upstash_team.exampleTeam.team_id
 }
 

--- a/examples/examples/team/outputs.tf
+++ b/examples/examples/team/outputs.tf
@@ -1,19 +1,19 @@
 output "team_id" {
-    value = data.upstash_team_data.teamData.team_id
+  value = data.upstash_team_data.teamData.team_id
 }
 
 output "team_name" {
-    value = data.upstash_team_data.teamData.team_name
+  value = data.upstash_team_data.teamData.team_name
 }
 
 output "team_members" {
-    value = data.upstash_team_data.teamData.team_members
+  value = data.upstash_team_data.teamData.team_members
 }
 
 output "copy_cc" {
-    value = resource.upstash_team.exampleTeam.copy_cc
+  value = resource.upstash_team.exampleTeam.copy_cc
 }
 
 output "copy_cc_from_data" {
-    value = data.upstash_team_data.teamData.copy_cc
+  value = data.upstash_team_data.teamData.copy_cc
 }

--- a/examples/examples/team/providers.tf
+++ b/examples/examples/team/providers.tf
@@ -1,4 +1,4 @@
 provider "upstash" {
-  email = var.email
+  email   = var.email
   api_key = var.api_key
 }

--- a/examples/examples/team/resources.tf
+++ b/examples/examples/team/resources.tf
@@ -1,7 +1,7 @@
 resource "upstash_team" "exampleTeam" {
-    team_name = var.team_name
-    copy_cc = var.copy_cc
-    team_members = var.team_members
+  team_name    = var.team_name
+  copy_cc      = var.copy_cc
+  team_members = var.team_members
 }
 
 # resource "upstash_team" "importTeam" {}

--- a/examples/examples/team/variables.tf
+++ b/examples/examples/team/variables.tf
@@ -7,9 +7,9 @@ variable "api_key" {
   default     = ""
 }
 
-variable "team_name"{}
-variable "copy_cc"{}
-variable "team_members"{
-  type = map
+variable "team_name" {}
+variable "copy_cc" {}
+variable "team_members" {
+  type = map(any)
 }
 

--- a/examples/examples/vector_index/providers.tf
+++ b/examples/examples/vector_index/providers.tf
@@ -1,4 +1,4 @@
 provider "upstash" {
-  email = var.email
+  email   = var.email
   api_key = var.api_key
 }

--- a/examples/examples/vector_index/variables.tf
+++ b/examples/examples/vector_index/variables.tf
@@ -1,36 +1,36 @@
 variable "email" {
-  default = "<YOUR MAIL ADDRESS>"
+  default     = "<YOUR MAIL ADDRESS>"
   description = "Upstash user email"
-  type = string
+  type        = string
 }
 
 variable "api_key" {
   default     = "<RELATED MANAGEMENT API KEY>"
   description = "Api key for the given user"
-  type = string
+  type        = string
 }
 
 variable "name" {
   default = "terraform_index"
-  type = string
+  type    = string
 }
 
 variable "similarity_function" {
   default = "COSINE"
-  type = string
+  type    = string
 }
 
 variable "dimension_count" {
   default = 1536
-  type = number
+  type    = number
 }
 
 variable "region" {
   default = "us-east-1"
-  type = string
+  type    = string
 }
 
 variable "type" {
   default = "payg"
-  type = string
+  type    = string
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,4 +1,4 @@
 provider "upstash" {
-  email = "FILL_HERE"
-  api_key  = "FILL_HERE"
+  email   = "FILL_HERE"
+  api_key = "FILL_HERE"
 }

--- a/examples/resources/upstash_kafka_cluster/resource.tf
+++ b/examples/resources/upstash_kafka_cluster/resource.tf
@@ -1,5 +1,5 @@
 resource "upstash_kafka_cluster" "exampleCluster" {
   cluster_name = "TerraformCluster"
-  region = "eu-west-1"
-  multizone = false
+  region       = "eu-west-1"
+  multizone    = false
 }

--- a/examples/resources/upstash_kafka_connector/resource.tf
+++ b/examples/resources/upstash_kafka_connector/resource.tf
@@ -1,39 +1,39 @@
 # Not necessary if the topic belongs to an already created cluster.
 resource "upstash_kafka_cluster" "exampleKafkaCluster" {
-    cluster_name = "Terraform_Upstash_Cluster"
-    region = "eu-west-1"
-    multizone = false
+  cluster_name = "Terraform_Upstash_Cluster"
+  region       = "eu-west-1"
+  multizone    = false
 }
 
 
 resource "upstash_kafka_topic" "exampleKafkaTopic" {
-    topic_name = "TerraformTopic"
-    partitions = 1
-    retention_time = 625135
-    retention_size = 725124
-    max_message_size = 829213
-    cleanup_policy = "delete"
-    
-    # Here, you can use the newly created kafka_cluster resource (above) named exampleKafkaCluster.
-    # And use its ID so that the topic binds to it.
+  topic_name       = "TerraformTopic"
+  partitions       = 1
+  retention_time   = 625135
+  retention_size   = 725124
+  max_message_size = 829213
+  cleanup_policy   = "delete"
 
-    # Alternatively, provide the ID of an already created cluster.
-    cluster_id = resource.upstash_kafka_cluster.exampleKafkaCluster.cluster_id
+  # Here, you can use the newly created kafka_cluster resource (above) named exampleKafkaCluster.
+  # And use its ID so that the topic binds to it.
+
+  # Alternatively, provide the ID of an already created cluster.
+  cluster_id = resource.upstash_kafka_cluster.exampleKafkaCluster.cluster_id
 }
 
 
 resource "upstash_kafka_connector" "exampleKafkaConnector" {
-    name = var.connector_name
-    cluster_id = upstash_kafka_cluster.exampleKafkaCluster.cluster_id
-    properties = {
-        "collection": "user123",
-        "connection.uri": "mongodb+srv://test:test@cluster0.fohyg7p.mongodb.net/?retryWrites=true&w=majority",
-        "connector.class": "com.mongodb.kafka.connect.MongoSourceConnector",
-        "database": "myshinynewdb2",
-        "topics": "${upstash_kafka_topic.exampleKafkaTopic.topic_name}"
-    }
-    
-    # OPTIONAL: change between restart-running-paused
-    # running_state = "running"
+  name       = var.connector_name
+  cluster_id = upstash_kafka_cluster.exampleKafkaCluster.cluster_id
+  properties = {
+    "collection" : "user123",
+    "connection.uri" : "mongodb+srv://test:test@cluster0.fohyg7p.mongodb.net/?retryWrites=true&w=majority",
+    "connector.class" : "com.mongodb.kafka.connect.MongoSourceConnector",
+    "database" : "myshinynewdb2",
+    "topics" : "${upstash_kafka_topic.exampleKafkaTopic.topic_name}"
+  }
+
+  # OPTIONAL: change between restart-running-paused
+  # running_state = "running"
 }
 

--- a/examples/resources/upstash_kafka_credential/resource.tf
+++ b/examples/resources/upstash_kafka_credential/resource.tf
@@ -1,31 +1,31 @@
 resource "upstash_kafka_cluster" "exampleKafkaCluster" {
-    cluster_name = var.cluster_name
-    region = var.region
-    multizone = var.multizone
+  cluster_name = var.cluster_name
+  region       = var.region
+  multizone    = var.multizone
 }
 
 
 resource "upstash_kafka_topic" "exampleKafkaTopic" {
-    topic_name = var.topic_name
-    partitions = var.partitions
-    retention_time = var.retention_time
-    retention_size = var.retention_size
-    max_message_size = var.max_message_size
-    cleanup_policy = var.cleanup_policy
-    cluster_id = resource.upstash_kafka_cluster.exampleKafkaCluster.cluster_id
+  topic_name       = var.topic_name
+  partitions       = var.partitions
+  retention_time   = var.retention_time
+  retention_size   = var.retention_size
+  max_message_size = var.max_message_size
+  cleanup_policy   = var.cleanup_policy
+  cluster_id       = resource.upstash_kafka_cluster.exampleKafkaCluster.cluster_id
 }
 
 resource "upstash_kafka_credential" "exampleKafkaCredential" {
-    cluster_id = upstash_kafka_cluster.exampleKafkaCluster.cluster_id
-    credential_name="credentialFromTerraform"
-    topic = upstash_kafka_topic.exampleKafkaTopic.topic_name
-    permissions = "ALL"
+  cluster_id      = upstash_kafka_cluster.exampleKafkaCluster.cluster_id
+  credential_name = "credentialFromTerraform"
+  topic           = upstash_kafka_topic.exampleKafkaTopic.topic_name
+  permissions     = "ALL"
 }
 
 resource "upstash_kafka_credential" "exampleKafkaCredentialAllTopics" {
-  cluster_id = upstash_kafka_cluster.exampleKafkaCluster.cluster_id
-  credential_name="credentialFromTerraform"
-  topic = "*"
-  permissions = "ALL"
+  cluster_id      = upstash_kafka_cluster.exampleKafkaCluster.cluster_id
+  credential_name = "credentialFromTerraform"
+  topic           = "*"
+  permissions     = "ALL"
 }
 

--- a/examples/resources/upstash_kafka_topic/resource.tf
+++ b/examples/resources/upstash_kafka_topic/resource.tf
@@ -1,22 +1,22 @@
 # Not necessary if the topic belongs to an already created cluster.
 resource "upstash_kafka_cluster" "exampleKafkaCluster" {
-    cluster_name = "Terraform_Upstash_Cluster"
-    region = "eu-west-1"
-    multizone = false
+  cluster_name = "Terraform_Upstash_Cluster"
+  region       = "eu-west-1"
+  multizone    = false
 }
 
 
 resource "upstash_kafka_topic" "exampleKafkaTopic" {
-    topic_name = "TerraformTopic"
-    partitions = 1
-    retention_time = 625135
-    retention_size = 725124
-    max_message_size = 829213
-    cleanup_policy = "delete"
-    
-    # Here, you can use the newly created kafka_cluster resource (above) named exampleKafkaCluster.
-    # And use its ID so that the topic binds to it.
+  topic_name       = "TerraformTopic"
+  partitions       = 1
+  retention_time   = 625135
+  retention_size   = 725124
+  max_message_size = 829213
+  cleanup_policy   = "delete"
 
-    # Alternatively, provide the ID of an already created cluster.
-    cluster_id = resource.upstash_kafka_cluster.exampleKafkaCluster.cluster_id
+  # Here, you can use the newly created kafka_cluster resource (above) named exampleKafkaCluster.
+  # And use its ID so that the topic binds to it.
+
+  # Alternatively, provide the ID of an already created cluster.
+  cluster_id = resource.upstash_kafka_cluster.exampleKafkaCluster.cluster_id
 }

--- a/examples/resources/upstash_qstash_endpoint/resource.tf
+++ b/examples/resources/upstash_qstash_endpoint/resource.tf
@@ -1,4 +1,4 @@
 resource "upstash_qstash_endpoint" "exampleQstashEndpoint" {
-    url = "https://***.***"
-    topic_id = resource.upstash_qstash_topic.exampleQstashTopic.topic_id
+  url      = "https://***.***"
+  topic_id = resource.upstash_qstash_topic.exampleQstashTopic.topic_id
 }

--- a/examples/resources/upstash_qstash_schedule/resource.tf
+++ b/examples/resources/upstash_qstash_schedule/resource.tf
@@ -1,7 +1,7 @@
 resource "upstash_qstash_schedule" "exampleQstashSchedule" {
-    destination = resource.upstash_qstash_topic.exampleQstashTopic.topic_id
-    cron = "* * * * */2"
+  destination = resource.upstash_qstash_topic.exampleQstashTopic.topic_id
+  cron        = "* * * * */2"
 
-    # or simply provide a link
-    # destination = "https://***.***"
+  # or simply provide a link
+  # destination = "https://***.***"
 }

--- a/examples/resources/upstash_redis_database/resource.tf
+++ b/examples/resources/upstash_redis_database/resource.tf
@@ -1,6 +1,6 @@
 resource "upstash_redis_database" "exampleDB" {
   database_name = "Terraform DB6"
-  region = "eu-west-1"
-  tls = "true"
-  multizone = "true"
+  region        = "eu-west-1"
+  tls           = "true"
+  multizone     = "true"
 }

--- a/examples/resources/upstash_team/resource.tf
+++ b/examples/resources/upstash_team/resource.tf
@@ -1,11 +1,11 @@
 resource "upstash_team" "exampleTeam" {
-    team_name = "TerraformTeam"
-    copy_cc = false
+  team_name = "TerraformTeam"
+  copy_cc   = false
 
-    team_members = {
-        # Owner is the owner of the api_key.
-        "X@Y.Z": "owner",
-        "A@B.C": "dev",
-        "E@E.F": "finance",
-    }
+  team_members = {
+    # Owner is the owner of the api_key.
+    "X@Y.Z" : "owner",
+    "A@B.C" : "dev",
+    "E@E.F" : "finance",
+  }
 }


### PR DESCRIPTION
## Why

On GitHub and on the Terraform Registry, I realized that all resources are not Terraform formatted.

Thus, I have ran `terraform fmt --recursive examples` to make the documents easier to read and more copy and paste-able.