### PR TITLE
Format Redis database example in `resources/`

### DIFF
--- a/docs/resources/redis_database.md
+++ b/docs/resources/redis_database.md
@@ -15,9 +15,9 @@ description: |-
 ```terraform
 resource "upstash_redis_database" "exampleDB" {
   database_name = "Terraform DB6"
-  region = "eu-west-1"
-  tls = "true"
-  multizone = "true"
+  region        = "eu-west-1"
+  tls           = true
+  multizone     = true
 }
 ```
 


### PR DESCRIPTION
## Why

This was left over from https://github.com/upstash/terraform-provider-upstash/pull/41 and needs formatting.

Also, I've noticed that some `Bool` arguments are written here as `String`. 
It still works, but strongly typed examples are better.