### PR TITLE
Upgrade Go to `v1.22`

### DIFF
--- a/.github/workflows/automated-test.yml
+++ b/.github/workflows/automated-test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.22
       - name: Build provider
         run: go build .
       - name: Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.21
+          go-version: 1.22
       - name: Import GPG key
         id: import_gpg
         uses: upstash/ghaction-import-gpg@v5

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/upstash/terraform-provider-upstash
 
-go 1.21
+go 1.22
 
 require (
 	github.com/gruntwork-io/terratest v0.40.0


### PR DESCRIPTION
## Why

I saw this PR https://github.com/upstash/terraform-provider-upstash/pull/34 and I want to bump to the latest Go release.